### PR TITLE
support for CH class

### DIFF
--- a/examples/chaos_class_resolve.cr
+++ b/examples/chaos_class_resolve.cr
@@ -1,0 +1,20 @@
+#query local bind server version using CH class, TXT record
+
+require "../src/durian.cr"
+
+buffer = uninitialized UInt8[4096_i32]
+
+request = Durian::Packet::Request.new
+
+request.queries << Durian::Section::Question.new Durian::RecordFlag::TXT, "version.bind", Durian::Cls::CH
+
+_request = IO::Memory.new request.to_slice
+puts [:Request, Durian::Packet::Request.from_io _request]
+
+udp_socket = UDPSocket.new
+udp_socket.connect Socket::IPAddress.new "127.0.0.1", 53_i32
+udp_socket.send _request.to_slice
+length, ip_address = udp_socket.receive buffer.to_slice
+
+_response = IO::Memory.new buffer.to_slice[0_i32, length]
+puts [:Response, Durian::Packet::Response.from_io _response]

--- a/src/durian/durian.cr
+++ b/src/durian/durian.cr
@@ -96,6 +96,8 @@ module Durian
 
   enum Cls : UInt16
     IN = 1_u16
+    CH = 3_u16  # rfc 2929
+    HS = 4_u16
   end
 
   class MalformedPacket < Exception


### PR DESCRIPTION
Adding the CH class allows to query the bind 'dummy' zones, in order to get statistics about the dns server itself. This is useful to analyze cache hit/miss ratio in caching resolvers.

https://miek.nl/2009/july/31/dns-classes/

some sample useful queries, tested in dnsmasq 2.80:
```
dig +short chaos txt version.bind
dig +short chaos txt servers.bind
dig +short chaos txt cachesize.bind
dig +short chaos txt insertions.bind
dig +short chaos txt evictions.bind
dig +short chaos txt hits.bind
dig +short chaos txt misses.bind
dig +short chaos txt auth.bind
```




