### PR TITLE
Update shards to crystal 1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,8 @@
 name: durian
 version: 0.1.5
 
+crystal: ">= 0.35.0, < 2.0.0"
+
 dependencies:
   coffee:
     github: 636f7374/coffee.cr


### PR DESCRIPTION
update to allow error less install on crystal 1.0.0. Currently errors out due to major version change on shards install.

there also should be a new version release as well.