### PR TITLE
Use Time::Span instead of Float and Int

### DIFF
--- a/src/durian/resolver.cr
+++ b/src/durian/resolver.cr
@@ -215,7 +215,7 @@ class Durian::Resolver
     Tuple.new fetch_list.type, ip_address
   end
 
-  def self.get_tcp_socket!(host : String, port : Int32, resolver : Resolver, connect_timeout : Int | Float? = nil) : ::TCPSocket
+  def self.get_tcp_socket!(host : String, port : Int32, resolver : Resolver, connect_timeout : Time::Span? = nil) : ::TCPSocket
     fetch_list = getaddrinfo_all host, port, resolver
     raise Socket::Error.new "DNS query result IP is empty, or DNS query failed" if fetch_list.empty?
 
@@ -232,7 +232,7 @@ class Durian::Resolver
     raise Socket::Error.new "Connection refused for all IP addresses"
   end
 
-  def self.get_udp_socket!(host : String, port : Int32, resolver : Resolver, connect_timeout : Int | Float? = nil) : ::UDPSocket
+  def self.get_udp_socket!(host : String, port : Int32, resolver : Resolver, connect_timeout : Time::Span? = nil) : ::UDPSocket
     fetch_list = getaddrinfo_all host, port, resolver
     raise Socket::Error.new "DNS query result IP is empty, or DNS query failed" unless first = fetch_list.first?
 

--- a/src/durian/socket/tcp_socket.cr
+++ b/src/durian/socket/tcp_socket.cr
@@ -1,5 +1,5 @@
 class Durian::TCPSocket < TCPSocket
-  def self.connect(host : String, port : Int32, resolver : Durian::Resolver, connect_timeout : Int | Float? = nil)
+  def self.connect(host : String, port : Int32, resolver : Durian::Resolver, connect_timeout : Time::Span? = nil)
     Resolver.get_tcp_socket! host, port, resolver, connect_timeout
   end
 


### PR DESCRIPTION
As of Crystal version 1.12.0 `Time::Span` should be used instead of `Int` and `Float`.